### PR TITLE
Add the possibility to apply tablesorter to all the tables of the page

### DIFF
--- a/tablesorter.yaml
+++ b/tablesorter.yaml
@@ -5,4 +5,3 @@ include_metadata: false
 production: true 
 custom_path: assets/tablesorter  #no leading or trailing slash
 themes: blue
-table_nums: 1


### PR DESCRIPTION
Hi Perlkonig,
I've made some improvements to your code because I need them for [my personal blog](http://www.gamecoderblog.com)

I think it could also interest the community.

I've added the possibility to apply tablesorter to all the tables (global setting).

- if the "table_nums" setting is absent or NULL, in the plugin config AND in the page parameters: tablesorter is applied to all the tables WITH the same settings.
- if the "table_nums" setting is set to 0 in the plugin config OR in the page parameter: tablesorter is applied to all the tables  WITH the same settings.
- if the "table_nums" setting is present and different from 0: same behavior than before plugin changes (allows individual table settings)

BR,
laurent